### PR TITLE
Fix default branch name on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
     tags: ['*']
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Change name of default branch from 'main' to 'master'